### PR TITLE
ThiagoCGG_APS6

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,42 @@ Também é possível executar o agente treinado em um único episódio, para iss
 python train_grid_world_obstacles.py run
 ```
 
-## Uso do ambiente GridWorld para problemas de Coverage Path Planning
+## Uso do ambiente GridWorld para Coverage Path Planning (CPP)
 
-**Sugestão**: considerando a última versão do ambiente GridWorld, com renderização e obstáculos, altere a função de *reward* e o que mais for necessário para que o agente aprenda a fazer *Coverage Path Planning* (CPP) em um ambiente 2D com obstáculos.
+### Função de reward atual
+
+A função de reward original do ambiente é baseada na distância entre o agente e o objetivo (target).
+
+Regras:
+
+- O agente recebe **+10.0** ao atingir o objetivo.
+- Caso contrário, a reward é dada por:
+  
+  `reward = (distância anterior - distância atual) - 0.1`
+
+  Ou seja:
+  - o agente é recompensado ao se aproximar do objetivo;
+  - é penalizado ao se afastar;
+  - há uma penalidade fixa de **-0.1 por passo**.
+
+- Se o número máximo de passos for atingido sem alcançar o objetivo:
+  
+  `reward = -10.0`
+
+Essa função incentiva o agente a chegar ao objetivo o mais rápido possível. No entanto, ela não é adequada para problemas de Coverage Path Planning (CPP), pois não considera a exploração ou cobertura do ambiente.
+
+---
+
+## Nova função de reward proposta para CPP
+
+Para adaptar o ambiente ao problema de Coverage Path Planning (CPP), a função de reward foi reformulada para incentivar a cobertura do ambiente.
+
+A nova reward segue as seguintes regras:
+
+- O agente recebe **+1.0** ao visitar uma célula ainda não explorada.
+- O agente recebe **-0.2** ao revisitar uma célula já visitada.
+- O agente recebe **-1.0** ao tentar se mover para uma célula ocupada por obstáculo.
+- Existe uma penalidade de **-0.1 por passo**, incentivando eficiência.
+- O episódio termina quando todas as células livres do grid forem visitadas, com uma recompensa final de **+10.0**.
+
+Essa nova definição incentiva o agente a explorar o ambiente de forma eficiente, evitando revisitas desnecessárias e cobrindo o maior número possível de células.

--- a/gymnasium_env/grid_world_obstacles.py
+++ b/gymnasium_env/grid_world_obstacles.py
@@ -102,6 +102,8 @@ class GridWorldRenderEnv(gym.Env):
 
         # Choose the agent's location uniformly at random
         self._agent_location = self.np_random.integers(0, self.size, size=2, dtype=int)
+        self.visited_cells = set()
+        self.visited_cells.add(tuple(self._agent_location))
 
         # We will sample the target's location randomly until it does not coincide with the agent's location
         self._target_location = self._agent_location
@@ -153,19 +155,25 @@ class GridWorldRenderEnv(gym.Env):
 
         self.set_neighbors(self.obstacles_locations)
 
-        # Calculate current distance
-        current_distance = self.distance(self._agent_location, self._target_location)
-
         self.count_steps += 1
-        
-        # An environment is completed if and only if the agent has reached the target
-        terminated = np.array_equal(self._agent_location, self._target_location)
 
-        # Calculate reward based on distance
+        current_cell = tuple(self._agent_location)
+        free_cells = self.size * self.size - len(self.obstacles_locations)
+
+        if current_cell not in self.visited_cells:
+            reward = 1.0
+            self.visited_cells.add(current_cell)
+        else:
+            reward = -0.2
+
+        # Penalidade fixa por passo
+        reward -= 0.1
+
+        # O episódio termina quando todas as células livres foram visitadas
+        terminated = len(self.visited_cells) >= free_cells
+
         if terminated:
             reward = 10.0
-        else:
-            reward = prev_distance - current_distance - 0.1
 
         if self.count_steps >= self.max_steps and not terminated:
             truncated = True


### PR DESCRIPTION
Este PR implementa uma nova função de reward para Coverage Path Planning (CPP) no ambiente GridWorld com obstáculos.

Alterações realizadas:
- Substituição da reward baseada em distância por uma reward baseada em cobertura
- Adição de controle de células visitadas
- Recompensa por visitar células novas e penalidade por revisitar células
- Término do episódio quando todas as células livres são cobertas
- Atualização do README com a documentação da reward original e da nova reward proposta

Participantes:
ThiagoCGGodoi